### PR TITLE
Revert "Add provenance when publishing to GitHub Packages"

### DIFF
--- a/.github/workflows/node-publish-github-packages.yaml
+++ b/.github/workflows/node-publish-github-packages.yaml
@@ -20,6 +20,6 @@ jobs:
           # Defaults to the user or organization that owns the workflow file
           scope: '@letsbuilda'
       - run: npm ci
-      - run: npm publish --provenance --access public
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It blew up with `Automatic provenance generation not supported outside of GitHub Actions`